### PR TITLE
Bumped ruby version according to Dockerfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.7.1'
+ruby '2.7.3'
 
 gem 'coveralls', require: false
 gem 'factory_girl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ DEPENDENCIES
   test-unit
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.7.3p183
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
Апнул версию Ruby в Gemfile, иначе команда `docker-compose run --rm ruby bash -c 'bundle install'` завершается ошибкой `Your Ruby version is 2.7.2, but your Gemfile specified 2.7.1`.  Проблема в том, что в Dockerfile образ наследуется из `ruby:2.7-buster` (сейчас это 2.7.2p137), а в Gemfile указана версия 2.7.1.